### PR TITLE
Auto release binaries actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,6 @@ jobs:
         with:
           files: |
             ./dist/easydnscli-${{matrix.TARGET}}
+            ./dist/easydnscli-${{matrix.TARGET}}.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            TARGET: x86_64-apple-darwin
+
+          - os: ubuntu-latest
+            TARGET: x86_64-unknown-linux-musl
+
+          - os: windows-latest
+            TARGET: x86_64-windows
+
+    name: Build
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: pip3 install requests pyinstaller
+
+      - name: Generate binary
+        run: pyinstaller --onefile easydns-restapi-cli -n easydnscli-${{matrix.TARGET}}
+
+      - name: Add binaries to release artifacts
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./dist/easydnscli-${{matrix.TARGET}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Get dependencies
-        run: pip3 install requests pyinstaller
+        run: |
+          pip install -U pip setuptools
+          pip install requests pyinstaller
 
       - name: Generate binary
         run: pyinstaller --onefile easydns-restapi-cli -n easydnscli-${{matrix.TARGET}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get dependencies
-        if: matrix.os == 'windows-latest'
-        run: pip install requests pyinstaller
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
 
-      - name: Get dependencies
-        if: matrix.os != 'windows-latest'
+      - name: Install dependencies
         run: |
-          pip3 install -U setuptools
-          pip3 install requests pyinstaller
+          python -m pip install --upgrade pip
+          pip install requests pyinstaller
 
       - name: Generate binary
         run: pyinstaller --onefile easydns-restapi-cli.py -n easydnscli-${{matrix.TARGET}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Get dependencies
+        if: matrix.os == 'windows-latest'
+        run: pip install requests pyinstaller
+
+      - name: Get dependencies
+        if: matrix.os != 'windows-latest'
         run: |
-          pip install -U pip setuptools
-          pip install requests pyinstaller
+          pip3 install -U setuptools
+          pip3 install requests pyinstaller
 
       - name: Generate binary
-        run: pyinstaller --onefile easydns-restapi-cli -n easydnscli-${{matrix.TARGET}}
+        run: pyinstaller --onefile easydns-restapi-cli.py -n easydnscli-${{matrix.TARGET}}
 
       - name: Add binaries to release artifacts
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: ci
 on:
   push:
     tags:
-      - "v*"
+      - "*"
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
closes #5

I personally don't use Python so it took some trial and error getting pip to work on all 3 platforms.

You can see on my fork that once `git tag 'something' && git push --tags` is called, Github Actions will create the binaries and release them under the tag.

PS. I recommend squashing these commits because I did some mess trying to get it to work.